### PR TITLE
More informative messages on sign-up form

### DIFF
--- a/app_db_setup.py
+++ b/app_db_setup.py
@@ -113,7 +113,7 @@ def save(connection, response):
         dates = conf_data["dates"]
         cur.execute(insert_dates, [dates["year"], dates["start_date"], dates["end_date"]])
         cur.execute(insert_users_all, [response["email"], response["name"], 
-                        response["slack_name"]])
+                        response["Slack name"]])
         cur.execute(insert_locations, [response["city"], response["state"], response["country"],
                         response["latitude"], response["longitude"], response["timezone"]])
         cur.execute("SELECT id FROM users_all WHERE email = %s;", [response["email"]])

--- a/app_db_setup.py
+++ b/app_db_setup.py
@@ -32,9 +32,10 @@ def init_db():
         cur.execute("""CREATE TABLE IF NOT EXISTS rounds (
                         id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                         year INTEGER NOT NULL,
+                        round_num INTEGER NOT NULL,
                         start_date DATE UNIQUE NOT NULL,
                         end_date DATE UNIQUE NOT NULL,
-                        CONSTRAINT round_dates UNIQUE (year, start_date, end_date));""")
+                        CONSTRAINT year_round UNIQUE (year, round_num));""")
         cur.execute("""CREATE TABLE IF NOT EXISTS users_all (
                         id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, 
                         email VARCHAR(255) UNIQUE NOT NULL,
@@ -97,8 +98,8 @@ def init_db():
 
 def save(connection, response):
     cur = connection.cursor()
-    insert_dates = """INSERT INTO rounds (year, start_date, end_date)
-                        VALUES (%s, %s, %s) ON CONFLICT ON CONSTRAINT round_dates DO NOTHING;"""
+    insert_dates = """INSERT INTO rounds (year, round_num, start_date, end_date)
+                        VALUES (%s, %s, %s, %s) ON CONFLICT ON CONSTRAINT year_round DO NOTHING;"""
     insert_users_all = """INSERT INTO users_all (email, name, slack_name)
                             VALUES (%s, %s, %s) ON CONFLICT (email) DO NOTHING;"""
     insert_locations = """INSERT INTO locations (city, state, country, latitude, longitude, timezone)
@@ -113,7 +114,8 @@ def save(connection, response):
 
     try:
         dates = conf_data["dates"]
-        cur.execute(insert_dates, [dates["year"], dates["start_date"], dates["end_date"]])
+        cur.execute(insert_dates, [dates["year"], dates["round_num"], 
+                        dates["start_date"], dates["end_date"]])
         cur.execute(insert_users_all, [response["email"], response["name"], 
                         response["Slack name"]])
         cur.execute(insert_locations, [response["city"], response["state"], response["country"],

--- a/app_db_setup.py
+++ b/app_db_setup.py
@@ -27,7 +27,7 @@ def init_db():
     try:
         # connect to the PostgreSQL server
         connection = psycopg2.connect(DATABASE_URL)
-        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        connection.autocommit = False
         cur = connection.cursor()
         cur.execute("""CREATE TABLE IF NOT EXISTS rounds (
                         id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -130,6 +130,7 @@ def save(connection, response):
                         response["relation_pref"], response["freq_pref"], response["gender_pref"], 
                         response["timezone_pref"], response["amount_buddies"], response["objectives"], 
                         response["personal_descr"], response["comments"], round_id])
+        connection.commit()
         st.success(f"""Thanks for signing up!
                     You will be notified about your buddy on {conf_data['dates']['start_date_html']}.""")
         st.balloons()
@@ -148,6 +149,7 @@ def save(connection, response):
                         message ``{conf_data["contact"]["slack"]}`` on the WWCodePython 
                         #buddymeup slack channel 🆘.""")
         print(e)
+        connection.rollback()
     connection.close()
 
 

--- a/app_db_setup.py
+++ b/app_db_setup.py
@@ -125,8 +125,8 @@ def save(connection, response):
         cur.execute("SELECT id FROM locations WHERE latitude = %s AND longitude = %s;",
                         [response["latitude"], response["longitude"]])
         loc_id = cur.fetchone()
-        cur.execute("SELECT id FROM rounds WHERE year = %s AND start_date = %s AND end_date = %s;",
-                        [dates["year"], dates["start_date"], dates["end_date"]])
+        cur.execute("SELECT id FROM rounds WHERE year = %s AND round_num = %s;",
+                        [dates["year"], dates["round_num"]])
         round_id = cur.fetchone()
         cur.execute(insert_users_rounds, [response["timestamp"], user_id, loc_id, 
                         response["gender"], response["age"], response["topic"], 

--- a/app_db_setup.py
+++ b/app_db_setup.py
@@ -155,7 +155,7 @@ def save(connection, response):
         print(e)
         connection.rollback()
     except KeyError as e:
-        e = str(e)[1:-1]
+        e = str(e)[1:-1]  # strip quote marks around string
         description = key_lookup(e)
         st.error(f"""It looks like there is a problem with the input for {description} 😅; 
                      please go back and check that your value is valid.""")
@@ -176,6 +176,8 @@ def key_lookup(e):
       'email': 'your email',
       'name': 'your name',
       'Slack name': 'your Slack name',
+      'city': 'your location',
+      'country': 'your location',
       'age': 'your age',
       'gender': 'your gender',
       'topic': 'the areas of Python you\'re focusing on',

--- a/app_db_setup.py
+++ b/app_db_setup.py
@@ -89,9 +89,11 @@ def init_db():
         cur.execute("""CREATE UNIQUE INDEX IF NOT EXISTS user_round_match_null
 	                    ON users_rounds (fk_user_id, fk_round_id)
 	                    WHERE fk_match_id IS NULL;""")
+        connection.commit()
         return connection
     except psycopg2.DatabaseError as e:
         print(e)
+        connection.rollback()
 
 def save(connection, response):
     cur = connection.cursor()

--- a/app_pages.py
+++ b/app_pages.py
@@ -641,6 +641,7 @@ def page_sign_up_python():
         if slack_pw_py or python_button:
             if slack_pw_py == correct_slack_pw_py:
                 participant_info = app_signup_form.signup()  # returns participant info as a dict
+                st.markdown("<br>", unsafe_allow_html=True)
                 if st.checkbox("I understand that my data is processed to (1) evaluate matching buddies from the pool of participants and to (2) notify me via email and slack about my buddy."):
                     if st.button("Submit"):
                         app_signup_form.save(participant_info)

--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -54,11 +54,9 @@ def signup():
     city = string.capwords(city.text_input("Your city"))
     state = state.text_input("Your state/province (if applicable)")
     country = country.text_input("Your country")
-    participant_info = {
-        "city": city,
-        "state": state,
-        "country": country
-    }
+    participant_info["city"] = city
+    participant_info["state"] = state
+    participant_info["country"] = country    
 
     # Get latitude and longitude of participant's location
     location_valid, latitude, longitude = get_lat_long(city, state, country)
@@ -68,13 +66,9 @@ def signup():
     
     draw_map(location_valid, latitude, longitude)  # will draw default map if location not valid
 
-    participant_info = {
-        "timezone": offset,
-        "latitude": latitude,
-        "longitude": longitude
-    }
-
-    participant_info = {}
+    participant_info["timezone"] = offset
+    participant_info["latitude"] = latitude 
+    participant_info["longitude"] = longitude 
 
     age, check = st.beta_columns(2)
     age = age.number_input("Age", min_value=0, max_value=100)
@@ -189,7 +183,7 @@ def signup():
     participant_info["comments"] = comments
 
     timestamp = datetime.now(tz=dt_timezone.utc)
-    participant_info["timestamp"]: timestamp.strftime("%Y/%m/%d %H:%M:%S")
+    participant_info["timestamp"] = timestamp.strftime("%Y/%m/%d %H:%M:%S")
 
     # Turn "topic" from array to string
     if "topic" in participant_info:

--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -33,8 +33,8 @@ def signup():
     participant_info = {}
 
     email, check = st.beta_columns(2)
-    email = email.text_input("Email")
-    if re.match(r'^.+@.+\..{2,3}$', email.strip()):
+    email = email.text_input("Email").strip()
+    if re.match(r'^.+@.+\..{2,3}$', email):
         check.markdown("<p style='margin-top: 40px'>&#10003</p>", unsafe_allow_html=True)
         participant_info["email"] = email
     else:  # invalid email
@@ -43,17 +43,17 @@ def signup():
     labels = ["name", "Slack name"]
     for label in labels:
         field, check = st.beta_columns(2)
-        field = field.text_input(string.capwords(label))
-        if len(field.strip()) < 2:  # should contain at least 2 chars
+        field = field.text_input(string.capwords(label)).strip()
+        if len(field) < 2:  # should contain at least 2 chars
             check.error(f"Please input your {label}")
         else:
             check.markdown("<p style='margin-top: 40px'>&#10003</p>", unsafe_allow_html=True)
             participant_info[label] = field
 
     city, state, country = st.beta_columns(3)
-    city = string.capwords(city.text_input("Your city"))
-    state = state.text_input("Your state/province (if applicable)")
-    country = country.text_input("Your country")
+    city = string.capwords(city.text_input("Your city")).strip()
+    state = state.text_input("Your state/province (if applicable)").strip()
+    country = country.text_input("Your country").strip()
 
     # Get latitude, longitude, and UTC offset of participant's location
     location_valid, latitude, longitude = get_lat_long(city, state, country)
@@ -90,7 +90,7 @@ def signup():
     topic = topic.multiselect("What area(s) of Python are you focusing on?",
                                 ("Data Science", "Machine Learning", "Mobile", "Backend", "Frontend"))
     if not topic:
-        check.error(f"Please input your focus topics")
+        check.error(f"Please input one or more focus topic(s)")
     else:
         check.markdown("<p style='margin-top: 40px'>&#10003</p>", unsafe_allow_html=True)
         participant_info["topic"] = topic
@@ -167,7 +167,7 @@ def signup():
     st.markdown("<br>", unsafe_allow_html=True)
     objectives = st.text_area("Your coding objectives", "")
     if len(objectives.strip()) < 100:
-        st.error("""Please tell us why you'd like to join BuddyMeUp in at least 100 characters; 
+        st.error("""Please tell us above why you'd like to join BuddyMeUp in at least 100 characters; 
                     the more descriptive, the better we could match you!""")
     else:
         participant_info["objectives"] = objectives
@@ -176,7 +176,7 @@ def signup():
     personal_descr = st.text_area("""Please give a little description about yourself 
                                         so that we can get to know you better""", "")
     if len(personal_descr.strip()) < 100:
-        st.error("""Please write at least 100 characters; 
+        st.error("""Please write at least 100 characters above; 
                     the more descriptive, the better we could match you!""")
     else:
         participant_info["personal_descr"] = personal_descr

--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -54,24 +54,24 @@ def signup():
     city = string.capwords(city.text_input("Your city"))
     state = state.text_input("Your state/province (if applicable)")
     country = country.text_input("Your country")
-    participant_info["city"] = city
-    participant_info["state"] = state
-    participant_info["country"] = country    
 
-    # Get latitude and longitude of participant's location
+    # Get latitude, longitude, and UTC offset of participant's location
     location_valid, latitude, longitude = get_lat_long(city, state, country)
     offset = utc_offset(location_valid, latitude, longitude)
+    
     if location_valid:
         print_timezone(offset)
+        participant_info["city"] = city
+        participant_info["state"] = state
+        participant_info["country"] = country    
+        participant_info["timezone"] = offset
+        participant_info["latitude"] = latitude 
+        participant_info["longitude"] = longitude 
     
     draw_map(location_valid, latitude, longitude)  # will draw default map if location not valid
 
-    participant_info["timezone"] = offset
-    participant_info["latitude"] = latitude 
-    participant_info["longitude"] = longitude 
-
     age, check = st.beta_columns(2)
-    age = age.number_input("Age", min_value=0, max_value=100)
+    age = age.number_input("Your age", min_value=0, max_value=100)
     if age < 16:
         check.error(f"Please input your age (at least 16)")
     else:
@@ -166,11 +166,12 @@ def signup():
     
     objectives = st.text_area("Your coding objectives", "")
     if len(objectives.strip()) < 100:
-        st.error("""Please write at least 100 characters; 
+        st.error("""Please tell us why you'd like to join BuddyMeUp in at least 100 characters; 
                     the more descriptive, the better we could match you!""")
     else:
         participant_info["objectives"] = objectives
 
+    st.markdown("<br>", unsafe_allow_html=True)
     personal_descr = st.text_area("""Please give a little description about yourself 
                                         so that we can get to know you better""", "")
     if len(personal_descr.strip()) < 100:
@@ -179,7 +180,8 @@ def signup():
     else:
         participant_info["personal_descr"] = personal_descr
 
-    comments = st.text_area("Comments", "")
+    st.markdown("<br>", unsafe_allow_html=True)
+    comments = st.text_area("Any comments you'd like to make", "")
     participant_info["comments"] = comments
 
     timestamp = datetime.now(tz=dt_timezone.utc)

--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -164,6 +164,7 @@ def signup():
         check.markdown("<p style='margin-top: 40px'>&#10003</p>", unsafe_allow_html=True)
         participant_info["relation_pref"] = relation_pref
     
+    st.markdown("<br>", unsafe_allow_html=True)
     objectives = st.text_area("Your coding objectives", "")
     if len(objectives.strip()) < 100:
         st.error("""Please tell us why you'd like to join BuddyMeUp in at least 100 characters; 

--- a/config.json
+++ b/config.json
@@ -1,9 +1,8 @@
 {
-  "round_num": 3,
-  "round_num_id": 91,
   "signup_open": "True",
   "dates": {
     "year": "2021",
+    "round_num": "3", 
     "start_date": "2021-07-05",
     "end_date": "2021-09-13",
     "signup_date_html": "June 21, 2021",


### PR DESCRIPTION
## Description

1. Disabled autocommit when writing to DB:
2. Added more informative error messages for users when sign-up submission is unsuccessful.
3. Added `round_num` column to `rounds` table in DB.

## Rationale
1. Previously, if user entered valid info for email, name, and Slack name, this would be added as a record into the `users_all` table even if other info (such as location, etc.) is invalid and thus no corresponding record would be created in `users_rounds` table.  This was because each `INSERT INTO table` statement was autocommited before the next statement.  If there were an error with inserting into the `users_rounds` table, the previous insert into `users_all` was not rolled back.  Modifying autocommit to false and rolling back changes if any user input is invalid would prevent writing anything to DB.
2.  From previous sign-up round, some users had trouble figuring out why their submissions were unsuccessful.  So we're adding more descriptive error messages to pinpoint exactly what needs to be checked.  E.g.:
![image](https://user-images.githubusercontent.com/3713541/122665079-8fcb1100-d1e8-11eb-9d0f-a81941a2c0fc.png)
3. `round_num` column together with `year` column will be used to identify any BuddyMeUp round.  `round_num` will typically range from 1 to 4 if there are four rounds in a year.

## Notes
Note that addition of `round_num` and removal of `round_num_id` in `config.json` will break the matching algorithm wherever it uses `round_num_id` to select records.  I will open an issue for this and will be fixed in a separate pull request.
