### PR TITLE
Lower-casing emails before writing to DB

### DIFF
--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -33,7 +33,7 @@ def signup():
     participant_info = {}
 
     email, check = st.beta_columns(2)
-    email = email.text_input("Email").strip()
+    email = email.text_input("Email").strip().lower()
     if re.match(r'^.+@.+\..{2,3}$', email):
         check.markdown("<p style='margin-top: 40px'>&#10003</p>", unsafe_allow_html=True)
         participant_info["email"] = email
@@ -165,16 +165,18 @@ def signup():
         participant_info["relation_pref"] = relation_pref
     
     st.markdown("<br>", unsafe_allow_html=True)
-    objectives = st.text_area("Your coding objectives", "")
+    objectives = st.text_area("Your coding objectives (at least 100 characters)", "")
     if len(objectives.strip()) < 100:
-        st.error("""Please tell us above why you'd like to join BuddyMeUp in at least 100 characters; 
+        st.error("""Please tell us above why you'd like to join BuddyMeUp 
+                    and what you're hoping to achieve in at least 100 characters; 
                     the more descriptive, the better we could match you!""")
     else:
         participant_info["objectives"] = objectives
 
     st.markdown("<br>", unsafe_allow_html=True)
     personal_descr = st.text_area("""Please give a little description about yourself 
-                                        so that we can get to know you better""", "")
+                                        so that we can get to know you better
+                                        (at least 100 characters)""", "")
     if len(personal_descr.strip()) < 100:
         st.error("""Please write at least 100 characters above; 
                     the more descriptive, the better we could match you!""")

--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -165,8 +165,8 @@ def signup():
         participant_info["relation_pref"] = relation_pref
     
     st.markdown("<br>", unsafe_allow_html=True)
-    objectives = st.text_area("Your coding objectives (at least 100 characters)", "")
-    if len(objectives.strip()) < 100:
+    objectives = st.text_area("Your coding objectives (at least 100 characters)", "").strip()
+    if len(objectives) < 100:
         st.error("""Please tell us above why you'd like to join BuddyMeUp 
                     and what you're hoping to achieve in at least 100 characters; 
                     the more descriptive, the better we could match you!""")
@@ -176,8 +176,8 @@ def signup():
     st.markdown("<br>", unsafe_allow_html=True)
     personal_descr = st.text_area("""Please give a little description about yourself 
                                         so that we can get to know you better
-                                        (at least 100 characters)""", "")
-    if len(personal_descr.strip()) < 100:
+                                        (at least 100 characters)""", "").strip()
+    if len(personal_descr) < 100:
         st.error("""Please write at least 100 characters above; 
                     the more descriptive, the better we could match you!""")
     else:
@@ -185,7 +185,7 @@ def signup():
 
     st.markdown("<br>", unsafe_allow_html=True)
     comments = st.text_area("Any comments you'd like to make", "")
-    participant_info["comments"] = comments
+    participant_info["comments"] = comments.strip()
 
     timestamp = datetime.now(tz=dt_timezone.utc)
     participant_info["timestamp"] = timestamp.strftime("%Y/%m/%d %H:%M:%S")


### PR DESCRIPTION
## Description
1. Small addition to previous PR: set user email input to all lower case before writing to DB (email is used as primary key in `users_all` table, so we don't want duplicates of the same email with only case variations).
2. Re-added reminder to write at least 100 characters in objectives and self-description inputs on sign-up form (a few users tended to miss this requirement during previous sign-up round -- so we wanted to make doubly clear this time round).