### PR TITLE
Moved attributes and topics to config file

### DIFF
--- a/app_explore_data.py
+++ b/app_explore_data.py
@@ -298,7 +298,7 @@ def encode_topics(df):
     # string to lowercase
     df = df.apply(lambda x: x.astype(str).str.lower())
 
-    for topic in q.topics_python:
+    for topic in conf_data["variables"]["topics"]:
         df[topic] = df["topic"].str.contains(topic).astype(int)
     df_formatted = df.drop(["topic"], axis=1)
 

--- a/app_explore_data.py
+++ b/app_explore_data.py
@@ -15,6 +15,8 @@ import matplotlib.pyplot as plt
 with open('config.json') as config_file:
     conf_data = json.load(config_file)
 
+topics = conf_data["variables"]["topics"]
+
 # Load the dataset
 def load_data():
     connection = dbs.init_db()
@@ -128,39 +130,23 @@ def sidebar_explorer(df):
                 """, unsafe_allow_html=True)
             # interest topic grouped by experience
             df_topics = encode_topics(df)
-            exp_topic_df = pd.DataFrame({
-                "data science": df_topics[df_topics["data science"] == 1]["experience"],
-                "machine learning": df_topics[df_topics["machine learning"] == 1]["experience"],
-                "mobile": df_topics[df_topics["mobile"] == 1]["experience"],
-                "backend": df_topics[df_topics["backend"] == 1]["experience"],
-                "frontend": df_topics[df_topics["frontend"] == 1]["experience"]
-            })
-            exp_topic_grouped_df = pd.DataFrame({
-                    "experience": ["No experience", "0-1 year", "1-3 years", "3+ years"],
-                    "data science": [sum(exp_topic_df["data science"] == "0 years, getting started"),
-                                    sum(exp_topic_df["data science"] == "0-1 year"),
-                                    sum(exp_topic_df["data science"] == "1-3 years"),
-                                    sum(exp_topic_df["data science"] == "3+ years")],
-                    "machine learning": [sum(exp_topic_df["machine learning"] == "0 years, getting started"),
-                                    sum(exp_topic_df["machine learning"] == "0-1 year"),
-                                    sum(exp_topic_df["machine learning"] == "1-3 years"),
-                                    sum(exp_topic_df["machine learning"] == "3+ years")],
-                    "mobile": [sum(exp_topic_df["mobile"] == "0 years, getting started"),
-                                    sum(exp_topic_df["mobile"] == "0-1 year"),
-                                    sum(exp_topic_df["mobile"] == "1-3 years"),
-                                    sum(exp_topic_df["mobile"] == "3+ years")],
-                    "frontend": [sum(exp_topic_df["frontend"] == "0 years, getting started"),
-                                    sum(exp_topic_df["frontend"] == "0-1 year"),
-                                    sum(exp_topic_df["frontend"] == "1-3 years"),
-                                    sum(exp_topic_df["frontend"] == "3+ years")],
-                    "backend": [sum(exp_topic_df["backend"] == "0 years, getting started"),
-                                    sum(exp_topic_df["backend"] == "0-1 year"),
-                                    sum(exp_topic_df["backend"] == "1-3 years"),
-                                    sum(exp_topic_df["backend"] == "3+ years")]
-            })
+            exp_topic_dict = {}
+            for topic in topics:
+                exp_topic_dict[topic] = df_topics[df_topics[topic] == 1]["experience"]
+            exp_topic_df = pd.DataFrame(exp_topic_dict)
+
+            exp_topic_grouped_dict = {}
+            for topic in topics:
+                exp_topic_grouped_dict[topic] = [sum(exp_topic_df[topic] == "0 years, getting started"),
+                                                sum(exp_topic_df[topic] == "0-1 year"),
+                                                sum(exp_topic_df[topic] == "1-3 years"),
+                                                sum(exp_topic_df[topic] == "3+ years")]
+
+            exp_topic_grouped_df = pd.DataFrame(exp_topic_grouped_dict)
+            exp_topic_grouped_df["experience"] = ["No experience", "0-1 year", "1-3 years", "3+ years"]
+
             selection = alt.selection_multi(fields=['Interest topic'], bind='legend')
-            topic_graph = alt.Chart(exp_topic_grouped_df).transform_fold(
-                ["data science", "machine learning", "mobile", "backend", "frontend"],
+            topic_graph = alt.Chart(exp_topic_grouped_df).transform_fold(topics,
                 as_ = ["Interest topic", "Num_buddies"]
             ).mark_bar(
                 opacity = 0.5

--- a/app_signup_form.py
+++ b/app_signup_form.py
@@ -16,7 +16,12 @@ from pytz import timezone, utc
 from timezonefinder import TimezoneFinder
 import geopandas
 import matplotlib.pyplot as plt
+import json
 
+with open('config.json') as config_file:
+    conf_data = json.load(config_file)
+
+topics = conf_data["variables"]["topics"]
 
 def signup():
     """
@@ -88,7 +93,7 @@ def signup():
 
     topic, check = st.beta_columns(2)
     topic = topic.multiselect("What area(s) of Python are you focusing on?",
-                                ("Data Science", "Machine Learning", "Mobile", "Backend", "Frontend"))
+                                ([topic.capitalize() for topic in topics]))
     if not topic:
         check.error(f"Please input one or more focus topic(s)")
     else:

--- a/attribute_scoring.py
+++ b/attribute_scoring.py
@@ -1,0 +1,124 @@
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.preprocessing import MinMaxScaler
+
+def set_weights(dfa):
+    # setting weights per item
+    weights_dict = {
+        "gender": 1,
+        "timezone": 0.8,
+        "experience": 0.9,
+        "age": 0.3,
+        "freq_pref": 0.5,
+        "relation_pref": 0.3,
+        "objectives": 0.01,
+        "personal_descr": 0.01
+    }
+    # setting topic weights to 1 for each topic
+    weight_topic = 1
+    topics_list = dfa.filter(regex="topic", axis=1).columns.tolist()
+    weights_topics = {w: weight_topic for w in topics_list}
+    weights_dict.update(weights_topics)
+    return weights_dict, topics_list
+
+
+def score_text_on_similarity(text_responses):
+    """
+    Function for scoring the similarity of text responses (objectives and personal interests)
+    between each pair of participants.
+
+    :return: N x N scores df (N = no. of participants).
+    """
+    vect = TfidfVectorizer(min_df=1, stop_words="english")
+    tfidf = vect.fit_transform(text_responses)
+    # tfidf is a sparse matrix with dimensions (no. of documents) * (no. of distinct words)
+    # Get whole matrix:
+    tfidf_matrix = tfidf.todense()
+
+    cos_similarity_matrix = np.zeros((tfidf_matrix.shape[0], tfidf_matrix.shape[0]))
+    for i in range(tfidf_matrix.shape[0]):
+        for j in range(tfidf_matrix.shape[0]):
+            cos_similarity_matrix[i][j] = cosine_similarity(tfidf_matrix[i], tfidf_matrix[j])
+
+    # rescale values to a scale of 0-1
+    min_max_scaler = MinMaxScaler()
+    cos_similarity_scaled = min_max_scaler.fit_transform(cos_similarity_matrix)
+
+    return cos_similarity_scaled
+
+def score_gender(dfa, pa, pb, gender_scores):
+    # preference matters
+    if dfa["gender_pref"].iloc[pa] == dfa["gender"].iloc[pb] and dfa["gender"].iloc[pb] != 3:
+        gender_score = 1
+    else:
+        gender_score = 0.5
+    gender_scores.append(gender_score)
+    return gender_scores
+
+
+def score_timezone(dfa, pa, pb, tz_scores):
+    # preference matters
+    # todo: alter scoring for timezone! "tz 12 is followed by tz 1"
+    tz_score_not_norm = abs(int(dfa["timezone"].iloc[pa]) - int(dfa["timezone"].iloc[pb]))
+    max = 26  # (dfa["timezone"].max()) - (dfa["timezone"].min()) # total of 26 different timezones
+    min = 0
+    if dfa["timezone_pref"].iloc[pa] == 0:  # if person a indicated preference for same timezone
+        tz_score = round(1 - (tz_score_not_norm - min) / (max - min), 2)
+    elif dfa["timezone_pref"].iloc[pa] == 1:  # if person indicated a preference for opposite timezones
+        tz_score = round((tz_score_not_norm - min) / (max - min), 2)
+    else:  # dfa["timezone_pref"].iloc[pa] == 2:  # if person indicated no preference for any timezone
+        tz_score = 0.5
+    tz_scores.append(tz_score)
+    return tz_scores
+
+def score_experience(dfa, pa, pb, experience_scores):
+    # mentor_choice (mentor or buddy) --> experience matters
+    experience_score_not_norm = abs(int(dfa["experience"].iloc[pa]) - int(dfa["experience"].iloc[pb]))
+    max = (dfa["experience"].max()) - (dfa["experience"].min())
+    min = 0
+
+    if dfa["mentor_choice"].iloc[
+        pa] == 2:  # if person indicated preference for buddy/mentor (2 = No. I prefer to be matched with someone on the same level or with more experience.)
+        experience_score = round(1 - (experience_score_not_norm - min) / (max - min), 2)
+    elif dfa["mentor_choice"].iloc[pa] == 1:  # if person indicated preference for mentee (1 = Yes. I would mentpr)
+        experience_score = round((experience_score_not_norm - min) / (max - min), 2)
+    else:  # if person indicated no preference for experience level (mentee or buddy)
+        experience_score = 0.5
+    experience_scores.append(experience_score)
+    return experience_scores
+
+
+def score_ordinals_on_distance(item, dfa, pa, pb, item_scores):
+    # ordinal variables where least distance matters
+    item_score_not_norm = abs(int(dfa[item].iloc[pa]) - int(dfa[item].iloc[pb]))
+    max = (dfa[item].max()) - (dfa[item].min())
+    min = 0
+    item_score = round(1 - (item_score_not_norm - min) / (max - min), 2)  # rescale values 0-1
+    item_scores.append(item_score)
+    return item_scores
+
+def score_binaries_on_equality(item, dfa, pa, pb, item_scores):
+    # binary items where similarity matters / items must match
+    if dfa[item].iloc[pa] == dfa[item].iloc[pb]:
+        item_score = 1
+    else:
+        item_score = 0
+    item_scores.append(item_score)
+    return item_scores
+
+
+def score_item_in_list(scores_dict, attr_list, dfa, pa, type="binary"):
+    for item in attr_list:
+        item_scores = []
+        for pb in range(len(dfa.index)):
+            if type == "binary":
+                item_scores = score_binaries_on_equality(item, dfa, pa, pb, item_scores)
+            elif type == "ordinal":
+                item_scores = score_ordinals_on_distance(item, dfa, pa, pb, item_scores)
+        scores_dict[item] = item_scores
+    return scores_dict
+
+
+

--- a/attribute_scoring.py
+++ b/attribute_scoring.py
@@ -1,4 +1,7 @@
-
+"""
+Helper file feeding into score.py
+Functions for the scoring of each individual attribute or type of attributes.
+"""
 import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "round_num_id" : "91",
   "dates": {
     "year": "2021",
-    "round_num": "2",
+    "round_num": "1",
     "start_date": "2021-07-05",
     "end_date": "2021-09-13",
     "signup_date_html": "June 21, 2021",

--- a/config.json
+++ b/config.json
@@ -1,8 +1,9 @@
 {
   "signup_open": "True",
+  "round_num_id" : "91",
   "dates": {
     "year": "2021",
-    "round_num": "3",
+    "round_num": "2",
     "start_date": "2021-07-05",
     "end_date": "2021-09-13",
     "signup_date_html": "June 21, 2021",
@@ -14,7 +15,7 @@
     "db_name": "buddymeup"
   },
   "filepath": {
-    "python": "datafiles_sens/python/pairing_"
+    "python": "datafiles_sens/python/"
   },
   "file_name": {
     "signups": "/survey_response.csv",

--- a/config.json
+++ b/config.json
@@ -26,5 +26,11 @@
   "contact": {
     "email": "buddymeup@womenwhocode.com",
     "slack": "@Isabella"
+  },
+  "variables": {
+    "attributes" : ["id", "email", "name", "slack_name", "gender", "timezone", "age", "topic",
+              "experience", "mentor_choice", "relation_pref", "freq_pref", "gender_pref",
+              "timezone_pref", "amount_buddies", "objectives", "personal_descr"],
+    "topics" : ["data science", "mobile", "machine learning", "backend", "frontend"]
   }
 }

--- a/db_queries.py
+++ b/db_queries.py
@@ -73,7 +73,7 @@ signup_info = (f" SELECT {signup_info_var}"
                f" WHERE r.round_num = {conf_data['dates']['round_num']} AND r.year = {conf_data['dates']['year']};")
 
 
-prior_part = (f"SELECT * FROM matches;")
+prior_part = (f"SELECT * FROM matches INNER JOIN rounds as r ON m.fk_round_id = r.id;")
 
 
 

--- a/db_queries.py
+++ b/db_queries.py
@@ -67,11 +67,10 @@ signup_info_var = "ua.{}, ua.{}, ua.{}, ua.{}, ur.{}, " \
 
 signup_info = (f" SELECT {signup_info_var}"
                f" FROM users_rounds as ur"
-               f" INNER JOIN users_all as ua"
-               f" ON ur.fk_user_id = ua.id"
-               f" INNER JOIN locations as l"
-               f" ON ur.fk_location_id = l.id" 
-               f" WHERE ur.fk_round_id = 91;") #15 is round two! 91 is sround 3
+               f" INNER JOIN users_all as ua ON ur.fk_user_id = ua.id"
+               f" INNER JOIN locations as l ON ur.fk_location_id = l.id" 
+               f" INNER JOIN rounds as r ON ur.fk_round_id = r.id"
+               f" WHERE r.round_num = {conf_data['dates']['round_num']} AND r.year = {conf_data['dates']['year']};")
 
 
 prior_part = (f"SELECT * FROM matches;")

--- a/db_queries.py
+++ b/db_queries.py
@@ -57,30 +57,13 @@ def m_single_insert(conn, df):
 
 
 
-
-
-
-
-
-
-
-
-
 ## QUERIES
-
-# add users_round_info_id here (add find solution for .csv)
-var = ['id', 'email', 'name', 'slack_name', 'gender', 'timezone', 'age',  'topic',
-              'experience', 'mentor_choice', 'relation_pref', 'freq_pref', 'gender_pref',
-              'timezone_pref', 'amount_buddies', 'objectives', 'personal_descr'] #todo put this into config file
-
-topics_python = ["data science", "mobile", "machine learning", "backend", "frontend"] #todo put this into config file
-
 
 signup_info_var = "ua.{}, ua.{}, ua.{}, ua.{}, ur.{}, " \
                   "l.{}, " \
                   "ur.{}, ur.{}, ur.{}, ur.{}, ur.{}, " \
                   "ur.{}, ur.{}, ur.{}, ur.{}, " \
-                  "ur.{}, ur.{}".format(*var) #*conf_data["var"]["python"]
+                  "ur.{}, ur.{}".format(*conf_data["variables"]["attributes"])
 
 signup_info = (f" SELECT {signup_info_var}"
                f" FROM users_rounds as ur"
@@ -89,8 +72,6 @@ signup_info = (f" SELECT {signup_info_var}"
                f" INNER JOIN locations as l"
                f" ON ur.fk_location_id = l.id" 
                f" WHERE ur.fk_round_id = 91;") #15 is round two! 91 is sround 3
-
-
 
 
 prior_part = (f"SELECT * FROM matches;")

--- a/main.py
+++ b/main.py
@@ -2,9 +2,6 @@ import prep as p
 import score as s
 import match as m
 import analyze_evaluate as ae
-
-
-
 track = "python"
 
 print("before __name__ guard")

--- a/match.py
+++ b/match.py
@@ -25,7 +25,7 @@ def save_matches(df_matched, track=track):
         dbq.m_single_insert(conn, matches_db)
     else:
         save = ".csv"
-        to_path = conf_data["filepath"][track] + str(conf_data["round_num"]) + "/"+ dt_today + conf_data["file_name"]["buddy_results"]
+        to_path = conf_data["filepath"][track] + str(conf_data["dates"]["round_num"]) + "/"+ dt_today + conf_data["file_name"]["buddy_results"]
         df_matched.to_csv(to_path, sep=',', decimal=".", encoding='utf-8', index=False, header=True)
     return print("saved {} to {}".format(track, save))
 
@@ -129,7 +129,7 @@ def pair_participants(data, df_matrix, email_ids, idx_dict):
     else:
         print("number of participants was even! No double buddies")
 
-    df_matched["round"] = conf_data["round_num"]
+    df_matched["round"] = conf_data["dates"]["round_num"]
     return df_matched
 
 

--- a/prep.py
+++ b/prep.py
@@ -55,7 +55,7 @@ def prep_csv_data(track = "cloud"):
             offset = asf.utc_offset(location_valid, latitude, longitude)
             timezone_list.append(offset)
 
-        cols = dbq.var.copy()
+        cols = conf_data["variables"]["attributes"].copy()
         cols.remove("timezone")
         df_og = pd.read_csv(file_path, usecols=cols)
         df_og.dropna(how="all", inplace=True)
@@ -78,7 +78,7 @@ def prep_db_data(track="python"):
         print("no data in local db, referring to .csv instead")
         file_path = conf_data["filepath"][track] + str(conf_data["dates"]["year"]) + "/" + \
                     str(conf_data["dates"]["round_num"]) + conf_data["file_name"]["signups"]
-        df_raw = pd.read_csv(file_path, usecols=dbq.var)
+        df_raw = pd.read_csv(file_path, usecols=conf_data["variables"]["attributes"])
 
     return make_df(df_raw)
   

--- a/prep.py
+++ b/prep.py
@@ -29,8 +29,8 @@ def prep_csv_data(track = "cloud"):
     """
 
     # for csv data # for cloud track or for python backup
-    file_path = conf_data["filepath"][track] + str(conf_data["round_num"]) + \
-                conf_data["file_name"]["signups"]
+    file_path = conf_data["filepath"][track] + str(conf_data["dates"]["year"]) + "/" +  \
+                str(conf_data["dates"]["round_num"]) + conf_data["file_name"]["signups"]
     # read google forms csv into pd.df
     try:
         df_timezone = pd.read_csv(file_path, usecols=["city", "state", "country"])
@@ -76,8 +76,8 @@ def prep_db_data(track="python"):
     conn.close()
     if df_raw.shape[0] == 0:
         print("no data in local db, referring to .csv instead")
-        file_path = conf_data["filepath"][track] + str(conf_data["round_num"]) + \
-                    conf_data["file_name"]["signups"]
+        file_path = conf_data["filepath"][track] + str(conf_data["dates"]["year"]) + "/" + \
+                    str(conf_data["dates"]["round_num"]) + conf_data["file_name"]["signups"]
         df_raw = pd.read_csv(file_path, usecols=dbq.var)
 
     return make_df(df_raw)

--- a/prep.py
+++ b/prep.py
@@ -115,32 +115,32 @@ def transform_data(df):
     df = df[df.columns.difference(string)]
 
     # encoding categorical data (where assignment matters)
-    df["timezone_pref"] = df["timezone_pref"].map(
+    df.loc[:, "timezone_pref"] = df["timezone_pref"].map(
         {"different timezone / nationality": 1, "same timezone": 0, "timezone doesn´t matter": 2})
-    df["relation_pref"] = df["relation_pref"].map(
+    df.loc[:, "relation_pref"] = df["relation_pref"].map(
         {'more structured - set schedule': 1, 'more casual - we will contact each other when we want to talk': 0})
 
-    df["gender"] = df["gender"].map(
+    df.loc[:, "gender"] = df["gender"].map(
         {"female": 1, "male": 0, "non-binary": 2, "do not want to disclose": 3})
-    df["gender_pref"] = df["gender_pref"].map(
+    df.loc[:, "gender_pref"] = df["gender_pref"].map(
         {"female": 1, "male": 0, "non-binary": 2, 'gender doesn´t matter to you': 3})
-    df["amount_buddies"] = df["amount_buddies"].map(
+    df.loc[:, "amount_buddies"] = df["amount_buddies"].map(
         {"i´d rather start with one!": 1, "sure!": 2})
-    df["freq_pref"] = df["freq_pref"].map(
+    df.loc[:, "freq_pref"] = df["freq_pref"].map(
         {"daily": 0, "weekly": 1, "bi-weekly": 2, "monthly": 3})
-    df["experience"] = df["experience"].map(
+    df.loc[:, "experience"] = df["experience"].map(
         {"0 years, getting started": 1,
          "0-1 year": 2,
          "1-3 years": 3,
          "3+ years": 4})
-    df["mentor_choice"] = df["mentor_choice"].map(
+    df.loc[:, "mentor_choice"] = df["mentor_choice"].map(
         {"Yes": 1,
          "No - I prefer to be matched with someone on the same level or with more experience": 2,
          "Either would be great": 0})
 
     # formatting numerical data
-    df["timezone"] = df["timezone"].apply(lambda x: float(x))
-    df["age"] = df["age"].apply(lambda x: (int(float(x))))
+    df.loc[:,"timezone"] = df["timezone"].apply(lambda x: float(x))
+    df.loc[:,"age"] = df["age"].apply(lambda x: (int(float(x))))
 
     # df with encoded columns and users_round_info_id
     email_ids = df["email"] # keep this to be able to manually check later

--- a/score.py
+++ b/score.py
@@ -6,42 +6,14 @@ Function for scoring algorithm
 
 import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
-import numpy as np
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.metrics.pairwise import cosine_similarity
 import json
 import db_queries as dbq
+import attribute_scoring as ats
 
 track = "python"
 
 with open('config.json') as config_file:
     conf_data = json.load(config_file)
-
-
-def calc_similarity(text_responses):
-    """
-    Function for scoring the similarity of text responses (objectives and personal interests)
-    between each pair of participants.
-
-    :return: N x N scores df (N = no. of participants).
-    """
-    vect = TfidfVectorizer(min_df=1, stop_words="english")
-    tfidf = vect.fit_transform(text_responses)
-    # tfidf is a sparse matrix with dimensions (no. of documents) * (no. of distinct words)
-    # Get whole matrix:
-    tfidf_matrix = tfidf.todense()
-
-    cos_similarity_matrix = np.zeros((tfidf_matrix.shape[0], tfidf_matrix.shape[0]))
-    for i in range(tfidf_matrix.shape[0]):
-        for j in range(tfidf_matrix.shape[0]):
-            cos_similarity_matrix[i][j] = cosine_similarity(tfidf_matrix[i], tfidf_matrix[j])
-
-    # rescale values to a scale of 0-1
-    min_max_scaler = MinMaxScaler()
-    cos_similarity_scaled = min_max_scaler.fit_transform(cos_similarity_matrix)
-
-    return cos_similarity_scaled
-
 
 def scoring_alg(fdf, data, idx_dict, track = track):
     """
@@ -56,100 +28,35 @@ def scoring_alg(fdf, data, idx_dict, track = track):
     """
     dfa = fdf.copy()
     dfa.apply(pd.to_numeric)
-
-    # setting weights per item
-    weights_dict = {
-        "gender": 1,
-        "timezone": 0.8,
-        "experience": 0.9,
-        "age": 0.3,
-        "freq_pref": 0.5,
-        "relation_pref": 0.3,
-        "objectives": 0.01,
-        "personal_descr": 0.01
-    }
-    # setting topic weights to 1 for each topic
-    weight_topic = 1
-    topics_list = dfa.filter(regex="topic", axis=1).columns.tolist()
-    weights_topics = {w: weight_topic for w in topics_list}
-
-    weights_dict.update(weights_topics)
+    weights_dict, topics_list = ats.set_weights(dfa) # setting weights per item
 
     scores_all = {}
     # N x N array of similarity scores for text-based responses
-    scores_objectives = calc_similarity(data["objectives"])
-    scores_descr = calc_similarity(data["personal_descr"])
+    scores_objectives = ats.score_text_on_similarity(data["objectives"])
+    scores_descr = ats.score_text_on_similarity(data["personal_descr"])
 
     for pa in range(len(dfa.index)):  # for pa = person a in df
         scores_dict = {}
-
+        # variables where preference matters: gender, timezone, mentor_choice/experience
+        # todo: add this to ats.score_item_in_list function
         gender_scores = []
         tz_scores = []
         experience_scores = []
         for pb in range(len(dfa.index)):  # pb = person b
-            # variables where preference matters: gender, timzone, mentor_choice/experience
-            # gender
-            if dfa["gender_pref"].iloc[pa] == dfa["gender"].iloc[pb] and dfa["gender"].iloc[pb] != 3:
-                gender_score = 1
-            else:
-                gender_score = 0.5
-            gender_scores.append(gender_score)
-
-            # timezone
-            # todo: alter scoring for timezone! "tz 12 is followed by tz 1"
-            tz_score_not_norm = abs(int(dfa["timezone"].iloc[pa]) - int(dfa["timezone"].iloc[pb]))
-            max = 26 # (dfa["timezone"].max()) - (dfa["timezone"].min()) # total of 26 different timezones
-            min = 0
-            if dfa["timezone_pref"].iloc[pa] == 0:  # if person a indicated preference for same timezone
-                tz_score = round(1 - (tz_score_not_norm - min) / (max - min), 2)
-            elif dfa["timezone_pref"].iloc[pa] == 1:  # if person indicated a preference for opposite timezones
-                tz_score = round((tz_score_not_norm - min) / (max - min), 2)
-            else:# dfa["timezone_pref"].iloc[pa] == 2:  # if person indicated no preference for any timezone
-                tz_score = 0.5
-            tz_scores.append(tz_score)
-
-            # mentor_choice (mentor or buddy) --> experience matters
-            experience_score_not_norm = abs(int(dfa["experience"].iloc[pa]) - int(dfa["experience"].iloc[pb]))
-            max = (dfa["experience"].max()) - (dfa["experience"].min())
-            min = 0
-
-            if dfa["mentor_choice"].iloc[pa] == 2:  # if person indicated preference for buddy/mentor (2 = No. I prefer to be matched with someone on the same level or with more experience.)
-                experience_score = round(1 - (experience_score_not_norm - min) / (max - min), 2)
-            elif dfa["mentor_choice"].iloc[pa] == 1:  # if person indicated preference for mentee (1 = Yes. I would mentpr)
-                experience_score = round((experience_score_not_norm - min) / (max - min), 2)
-            else: # if person indicated no preference for experience level (mentee or buddy)
-                experience_score = 0.5
-            experience_scores.append(experience_score)
-
+            gender_scores = ats.score_gender(dfa, pa, pb, gender_scores)
+            tz_scores = ats.score_timezone(dfa, pa, pb, tz_scores)
+            experience_scores = ats.score_experience(dfa, pa, pb, experience_scores)
         scores_dict["gender"] = gender_scores
         scores_dict["timezone"] = tz_scores
         scores_dict["experience"] = experience_scores
 
-        # ordinal variables where least distance matters
-        list_ord = ["age", "freq_pref"]
-        for item in list_ord:
-            item_scores = []
-            for pb in range(len(dfa.index)):
-                item_score_not_norm = abs(int(dfa[item].iloc[pa]) - int(dfa[item].iloc[pb]))
-                max = (dfa[item].max()) - (dfa[item].min())
-                min = 0
-                item_score = round(1 - (item_score_not_norm - min) / (max - min), 2)  # rescale values 0-1
-                item_scores.append(item_score)
-            scores_dict[item] = item_scores
-
         # binary items where similarity matters / items must match
+        # ordinal variables where least distance matters
         list_bin = ["relation_pref"]
         list_bin.extend(topics_list)
-
-        for item in list_bin:
-            item_scores = []
-            for pb in range(len(dfa.index)):
-                if dfa[item].iloc[pa] == dfa[item].iloc[pb]:
-                    item_score = 1
-                else:
-                    item_score = 0
-                item_scores.append(item_score)
-            scores_dict[item] = item_scores
+        list_ord = ["age", "freq_pref"]
+        scores_dict = ats.score_item_in_list(scores_dict, list_bin, dfa, pa, type="binary")
+        scores_dict = ats.score_item_in_list(scores_dict, list_ord, dfa, pa, type="ordinal")
 
         # text-based responses: objectives and self-descriptions
         scores_dict["objectives"] = scores_objectives[pa][:]
@@ -181,7 +88,6 @@ def scoring_alg(fdf, data, idx_dict, track = track):
             idm_2 = idx_dict[id_2]
             df_matrix.loc[idm_1, idm_2] = 0
             print("checked for prior buddies!")
-
     except:
         pass
 

--- a/score.py
+++ b/score.py
@@ -116,7 +116,7 @@ def prior_buddy_check(idx_dict, track):
         df_m.dropna(how="all", inplace=True)
 
     # get lists of all participants prior this round, all participants of this round that have been in prior rounds too
-    df_prev = df_m[df_m["fk_round_id"] != conf_data["round_num_id"]]
+    df_prev = df_m[df_m["round_num"] != conf_data["dates"]["round_num"]]
     userid_current = idx_dict.values()
     userid_past = {*list(df_prev["fk_user_1_id"]), *list(df_prev["fk_user_2_id"])}
     userid_repeating = set(list(set(userid_current) & set(userid_past)))


### PR DESCRIPTION
## Description
* Updated SQL query to query by round_num and year instead of round_num_id
* Added topics and attributes to config_file
* Updated graphs and signup form, retrieving topics from 1 source: config_file


## Rationale
Not hard-coding the attributes but instead having them configurable in one place makes it easier to keep the overview, and gives flexibility in changing attributes/topics for signup or matching.

## Note
Did not delete round_num_id from config_file because the following issue is not resolved yet:
When writing matches to the db (in db_queries), round_num_id is still used. Once this is fixed, round_num_id can be safely deleted!